### PR TITLE
Fix translation not matching

### DIFF
--- a/src/components/translation/locale/de-DE.ts
+++ b/src/components/translation/locale/de-DE.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/el-GR.ts
+++ b/src/components/translation/locale/el-GR.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/en-GB.ts
+++ b/src/components/translation/locale/en-GB.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/en-US.ts
+++ b/src/components/translation/locale/en-US.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/es-ES.ts
+++ b/src/components/translation/locale/es-ES.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","Dock familiar, máxima forma");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","Todos conocen el dock o la barra de tareas. Te traemos un nuevo dock, con más características que lo que hay actualmente.");
 translation.set("brand new launch menu","Nuevo menú Inicio");
 translation.set("with everything in one place, do anything anywhere at anytime.","Con todo en un lugar, haz lo que quieras en todo lugar, en cualquier momento.");
-translation.set("easily apply layout.","Nuevo diseño aplicable");
+translation.set("easily apply layout","Nuevo diseño aplicable");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   "Con una lista de opciones preestablecidas, comienza a trabajar con este diseño perfecto de ventanas. ¿No es suficiente? Cámbialo en Ajustes."

--- a/src/components/translation/locale/fr-FR.ts
+++ b/src/components/translation/locale/fr-FR.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","Dock familier, forme ultime");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","tout le monde connais le dock/la barre des tâches. nous en avons un tout nouveau, avec encore plus de fonctionnalités que jamais auparavant");
 translation.set("brand new launch menu","Tout nouveau menu de démarrage");
 translation.set("with everything in one place, do anything anywhere at anytime.","Avec tout dans un seul endroit, faites ce que vous voulez, n'importe où à n'importe quel moment");
-translation.set("easily apply layout.","Appliquez facilement une disposition");
+translation.set("easily apply layout","Appliquez facilement une disposition");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   "Avec une liste de prédispositions définies depuis vos applications, travaillez facilement avec l'organisation parfaite de vos fenêtres. pas assez de dispositions ? changez les dans les paramètres"

--- a/src/components/translation/locale/hi.ts
+++ b/src/components/translation/locale/hi.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/id-ID.ts
+++ b/src/components/translation/locale/id-ID.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","dermaga akrab, bentuk pamungkas"
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","semua orang tahu dok/bilah tugas. kami mendapatkan dok baru, dengan lebih banyak fitur daripada sebelumnya");
 translation.set("brand new launch menu","menu peluncuran baru");
 translation.set("with everything in one place, do anything anywhere at anytime.","dengan segala sesuatu di satu tempat, lakukan apa saja di mana saja kapan saja.");
-translation.set("easily apply layout.","dengan mudah menerapkan tata letak.");
+translation.set("easily apply layout","dengan mudah menerapkan tata letak");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   "dengan daftar prasetel yang ditentukan dari aplikasi anda, mulai bekerja dengan mudah dengan tata letak jendela yang sempurna. tidak cukup? ubah di pengaturan."

--- a/src/components/translation/locale/it-IT.ts
+++ b/src/components/translation/locale/it-IT.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","Dock familiare, forma definitiva
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","Tutti conoscono la dock/task bar. noi abbiamo una nuova dock, con più funzionalità di prima.");
 translation.set("brand new launch menu","Nuovo menù di lancio");
 translation.set("with everything in one place, do anything anywhere at anytime.","Con tutto nello stesso posto, fai di tutto ogni momento.");
-translation.set("easily apply layout.","Applica facilmente il layout");
+translation.set("easily apply layout","Applica facilmente il layout");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   "Con un elenco di preset determinati dalle tue app, puoi facilmente lavorare con il layout perfetto della finestra. non abbastanza? cambialo nelle impostazioni."

--- a/src/components/translation/locale/nl-NL.ts
+++ b/src/components/translation/locale/nl-NL.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/pl.ts
+++ b/src/components/translation/locale/pl.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/ru.ts
+++ b/src/components/translation/locale/ru.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","");
 translation.set("brand new launch menu","");
 translation.set("with everything in one place, do anything anywhere at anytime.","");
-translation.set("easily apply layout.","");
+translation.set("easily apply layout","");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   ""

--- a/src/components/translation/locale/sr-SP.ts
+++ b/src/components/translation/locale/sr-SP.ts
@@ -50,7 +50,7 @@ translation.set("familiar dock, ultimate form","препознатљив док,
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","свако зна за док/радне траке. ми добијамо потпуно нов док, са више могућности него икад пре.");
 translation.set("brand new launch menu","потпуно нов почетни мени");
 translation.set("with everything in one place, do anything anywhere at anytime.","са свиме на једним местом, радите било шта било кад.");
-translation.set("easily apply layout.","лако постављен изглед");
+translation.set("easily apply layout","лако постављен изглед");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   "са листом шаблона одрећених из ваших апликација, лако пређите на посао у савршеном окружењу. није довољно? промените то у подешавањима."

--- a/src/components/translation/locale/zh-CN.ts
+++ b/src/components/translation/locale/zh-CN.ts
@@ -51,7 +51,7 @@ translation.set("familiar dock, ultimate form","熟悉的 Dock，终极形态");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","每个人都知道Dock/任务栏。我们有了一个全新的 Dock，比以往任何时候都拥有更多的功能。");
 translation.set("brand new launch menu","全新的启动菜单");
 translation.set("with everything in one place, do anything anywhere at anytime.","一切皆在一处，随时随地做任何事");
-translation.set("easily apply layout.","轻松选择排布");
+translation.set("easily apply layout","轻松选择排布");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   "直接从预设里选择，轻松使用完美的窗口排布。不满足？在设定里更改它。"

--- a/src/components/translation/locale/zh-TW.ts
+++ b/src/components/translation/locale/zh-TW.ts
@@ -51,7 +51,7 @@ translation.set("familiar dock, ultimate form","熟悉的 Dock，終極形態");
 translation.set("everyone know dock/task bar. we got a brand new dock, with more features than ever before.","每個人都知道Dock/任務欄。我們有了一個全新的 Dock，比以往任何時候都擁有更多的功能。");
 translation.set("brand new launch menu","全新的啟動菜單");
 translation.set("with everything in one place, do anything anywhere at anytime.","一切皆在一處，隨時隨地做任何事");
-translation.set("easily apply layout.","輕鬆選擇排佈");
+translation.set("easily apply layout","輕鬆選擇排佈");
 translation.set(
   "with a list of presets determined from you apps, easily get to work with the perfect window layout. not enough? change it in the settings.",
   "直接從預設裡選擇，輕鬆使用完美的窗口排佈。不滿足？在設定裡更改它。"

--- a/src/pages/features-beta.tsx
+++ b/src/pages/features-beta.tsx
@@ -95,7 +95,7 @@ const Features = () => {
           <FeaturesBetaCard
             isCardOnRight={false}
             title="Familiar dock, ultimate form"
-            description="Everyone know dock/task bar. We got a brand new dock, with more features than ever before. "
+            description="Everyone know dock/task bar. We got a brand new dock, with more features than ever before."
           />
           <Spacer h="1000px" />
           <FeaturesBetaCard
@@ -131,7 +131,7 @@ const Features = () => {
           <FeaturesBetaCard
             isCardOnRight={false}
             title="More than multitask"
-            description="Want to do many tasks at a time? We know you and we got you. It's now not only multitasking, it's organized multitasking."
+            description="Want to do many tasks at a time? We know you and we got you. It's now not only multitasking, it's organised multitasking."
           />
           <Spacer h="600px" />
           <FeaturesBetaCard


### PR DESCRIPTION
Idk why translation didn't match and thus fail to translate. Anyways, here's the patch.

![vibe](https://user-images.githubusercontent.com/51555391/176177206-ec3f9dce-8780-4fe8-b6ac-5eeeac2038d4.gif)