### PR TITLE
Changed Youtube URL to new YouTube URL in support.tsx

### DIFF
--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -35,7 +35,7 @@ const Support = () => {
           <SupportCard
             icon="YouTube"
             title="YouTube"
-            link="https://www.youtube.com/c/AvdanOSDeveloper"
+            link="https://www.youtube.com/channel/UCHLCBj83J7bR82HwjhCJusA"
             mobileLayout={mobileLayout}
           />
           <SupportCard icon="Discord" title="Discord" link="https://discord.gg/avdanos" mobileLayout={mobileLayout} />


### PR DESCRIPTION
Noticed that the YouTube URL in the support page was pointing to a 404 page. So I changed it to the new YouTube channel.