### PR TITLE
"İncele" should have been spelled with "İ" not "I"

### DIFF
--- a/src/public/assets/lang/tr_TR.yaml
+++ b/src/public/assets/lang/tr_TR.yaml
@@ -119,7 +119,7 @@ check it out: İncele
 # docs.tsx
 read the features in detail.: Özellikleri detaylı olarak incele.
 i'm a user: Bir Kullanıcıyım
-open manual: Kılavuzu incele
+open manual: Kılavuzu İncele
 manual is not available yet: Kılavuz henüz hazır değil
 i'm a developer: Bir Geliştiriciyim
 open documentation: Dokümantasyonu aç


### PR DESCRIPTION
I forgot to capitalize the "i", which resulted in it being an "I", not an "İ" when capitalized. Please capitalize it the way I did. 