### PR TITLE
New form issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report(beta).yml
+++ b/.github/ISSUE_TEMPLATE/bug_report(beta).yml
@@ -9,22 +9,22 @@ body:
         ### Before you start
 
         **Are you looking for development help?**
-        ↩ Please note that we cannot provide assistance on web development. We recommend asking around on a dedicated help forum like StackOverflow.
+        ↩ We don't provide development help here. Please search for help on Google, Stack Overflow, or our [Discord server](https://discord.gg/avdanos).
 
-        **Is your issue about content on an MDN page besides the compatibility table?**
-        ↩ Use the _Report a problem with this content on GitHub_ link at the bottom of the page.
+        **Do you have a question?**
+        ↩ Use the _community_ tab to ask questions.
+
+        **Does your issue already exist?**
+        ↩ Please search for existing issue before making a new one.
+
+        **Is your issue about feature request or grammar/translation?**
+        ↩ Submit a different type of issue on the _issue_ tab.
+
+        **Is your issue about another repository?**
+        ↩ Please only submit issues related to the website here. Issues related to the documentation should be submitted on the [docsite repositoy](https://github.com/Avdan-OS/Docsite).
 
         **Need help with a browser?**
         🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
-
-        ### Issue etiquette
-
-        When opening an issue, please:
-        - Follow the project's [Code of Conduct](https://github.com/mdn/browser-compat-data/blob/main/CODE_OF_CONDUCT.md) as well as the [GitHub Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines). Failure to comply may result in exclusion from MDN Web Docs and/or GitHub.
-        - Check for an [existing issue](https://github.com/mdn/browser-compat-data/issues) first. If someone else has opened an issue describing the same problem, please upvote their issue rather than creating another one.
-        - Keep issues relevant to the project. Irrelevant issues will be automatically closed and marked as spam, and repeated offenses may result in exclusion from MDN Web Docs.
-        - Provide as much detail as possible. The more detail you are able to provide, the better!
-        - Write issues primarily in English. While translation tools are available, we will be able to provide better assistance with pre-translated content. You are more than welcome to include a version of the issue body in your preferred language alongside the English version.
 
         ---
   - type: checkboxes
@@ -33,14 +33,13 @@ body:
       label: Tested on
       description: Please select the browsers that you have tested the issue on.
       options:
-        - label: Safari / any iOS browser (Webkit)
-        - label: Firefox/Tor (Gecko+Quantum)
+        - label: Safari, any iOS browser (Webkit)
+        - label: Firefox, Tor (Gecko+Quantum)
         - label: Chrome, Brave, Edge, Opera (Chromium)
   - type: checkboxes
     id: latest
     attributes:
-      label: Latest Version
-      description: Please make sure your browser is maintained and up to date before submitting any issue.
+      label: Please make sure your browser is maintained and up to date
       options:
         - label: Yes, my browser is maintained and up to date
           required: true
@@ -69,8 +68,8 @@ body:
   - type: textarea
     id: references
     attributes:
-      label: Can you link to any release notes, caniuse, bugs, pull requests, or MDN pages related to this?
-      description: Link to information that helps us fix this issue.
+      label: Provide us links that can help us fix this issue, if you have any.
+      description: Ex. any release notes, caniuse, bugs, pull requests, or MDN pages
   - type: textarea
     id: more-info
     attributes:
@@ -79,8 +78,7 @@ body:
   - type: checkboxes
     id: duplicate
     attributes:
-      label: Not duplicated
-      description: Please make sure this issue is not a duplicate of an existing issue.
+      label: Please make sure this issue is not a duplicate of an existing issue.
       options:
         - label: Yes, I have search for this issue on this repository and none were found
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report(beta).yml
+++ b/.github/ISSUE_TEMPLATE/bug_report(beta).yml
@@ -30,8 +30,7 @@ body:
   - type: checkboxes
     id: browser
     attributes:
-      label: Tested on
-      description: Please select the browsers that you have tested the issue on.
+      label: Please select the browsers that you have tested the issue on.
       options:
         - label: Safari, any iOS browser (Webkit)
         - label: Firefox, Tor (Gecko+Quantum)
@@ -46,11 +45,9 @@ body:
   - type: textarea
     attributes:
       label: What page(s) does this issue affect?
-    validations:
-      required: true
   - type: dropdown
     attributes:
-      label: What could be a potential cause of the issue?
+      label: What could be the potential cause of the issue?
       options:
         - Unknown
         - Front end (Browser compatibility)

--- a/.github/ISSUE_TEMPLATE/bug_report(beta).yml
+++ b/.github/ISSUE_TEMPLATE/bug_report(beta).yml
@@ -1,7 +1,8 @@
 name: "Bug Report (Beta)"
 title: "[Bug] - Title"
-description: Report bugs on the website (using the new form GitHub feature).
+description: Report bugs on the website (using the new GitHub form issue).
 labels: ["bug"]
+assignees: ["Froxcey", "AZProductions"]
 body:
   - type: markdown
     attributes:
@@ -12,7 +13,7 @@ body:
         ↩ We don't provide development help here. Please search for help on Google, Stack Overflow, or our [Discord server](https://discord.gg/avdanos).
 
         **Do you have a question?**
-        ↩ Use the _community_ tab to ask questions.
+        ↩ Please ask it on our [Discord server](https://discord.gg/avdanos)
 
         **Does your issue already exist?**
         ↩ Please search for existing issue before making a new one.
@@ -42,6 +43,18 @@ body:
       options:
         - label: Yes, my browser is maintained and up to date
           required: true
+  - type: checkboxes
+    id: os
+    attributes:
+      label: Please select the operating system that you have tested the issue on.
+      options:
+        - label: Linux based (Debian, Ubuntu, Arch, Fedora etc.)
+        - label: MacOS
+        - label: Windows
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Please put your hardware/model information here.
   - type: textarea
     attributes:
       label: What page(s) does this issue affect?

--- a/.github/ISSUE_TEMPLATE/bug_report(beta).yml
+++ b/.github/ISSUE_TEMPLATE/bug_report(beta).yml
@@ -58,10 +58,13 @@ body:
   - type: textarea
     id: details
     attributes:
-      label: Explain what went wrong
+      label: Please explain what went wrong.
+      description: Please include as much information as possible.
+    validations:
+      required: true
   - type: textarea
     attributes:
-      label: What pages does this issue affect?
+      label: Please list pages that this issue is related to.
   - type: dropdown
     attributes:
       label: What do you think could be the potential cause of the issue?
@@ -88,3 +91,7 @@ body:
       options:
         - label: Yes, I have search for this issue on this repository and none were found
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filling this bug report, and we will try to respond as soon as possible.

--- a/.github/ISSUE_TEMPLATE/bug_report(beta).yml
+++ b/.github/ISSUE_TEMPLATE/bug_report(beta).yml
@@ -31,7 +31,7 @@ body:
   - type: checkboxes
     id: browser
     attributes:
-      label: Please select the browsers that you have tested the issue on.
+      label: Please select the browsers that you have tested this issue on.
       options:
         - label: Safari, any iOS browser (Webkit)
         - label: Firefox, Tor (Gecko+Quantum)
@@ -39,14 +39,14 @@ body:
   - type: checkboxes
     id: latest
     attributes:
-      label: Please make sure your browser is maintained and up to date
+      label: Please make sure your browsers is maintained and up to date
       options:
         - label: Yes, my browser is maintained and up to date
           required: true
   - type: checkboxes
     id: os
     attributes:
-      label: Please select the operating system that you have tested the issue on.
+      label: Please select the operating system that you have tested this issue on.
       options:
         - label: Linux based (Debian, Ubuntu, Arch, Fedora etc.)
         - label: MacOS
@@ -56,11 +56,15 @@ body:
     attributes:
       label: Please put your hardware/model information here.
   - type: textarea
+    id: details
     attributes:
-      label: What page(s) does this issue affect?
+      label: Explain what went wrong
+  - type: textarea
+    attributes:
+      label: What pages does this issue affect?
   - type: dropdown
     attributes:
-      label: What could be the potential cause of the issue?
+      label: What do you think could be the potential cause of the issue?
       options:
         - Unknown
         - Front end (Browser compatibility)
@@ -68,18 +72,10 @@ body:
         - System error (VPS problem)
         - Other
   - type: textarea
-    id: details
-    attributes:
-      label: Explain what went wrong
-  - type: textarea
-    id: tested
-    attributes:
-      label: Did you test this? If so, how?
-  - type: textarea
     id: references
     attributes:
       label: Provide us links that can help us fix this issue, if you have any.
-      description: Ex. any release notes, caniuse, bugs, pull requests, or MDN pages
+      description: Ex. Any release notes, caniuse, bugs, pull requests, or MDN pages
   - type: textarea
     id: more-info
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report(beta).yml
+++ b/.github/ISSUE_TEMPLATE/bug_report(beta).yml
@@ -1,0 +1,86 @@
+name: "Website Bug Report"
+title: "[Bug] - Title"
+description: Report software bugs on the website.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Are you looking for development help?**
+        ↩ Please note that we cannot provide assistance on web development. We recommend asking around on a dedicated help forum like StackOverflow.
+
+        **Is your issue about content on an MDN page besides the compatibility table?**
+        ↩ Use the _Report a problem with this content on GitHub_ link at the bottom of the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ### Issue etiquette
+
+        When opening an issue, please:
+        - Follow the project's [Code of Conduct](https://github.com/mdn/browser-compat-data/blob/main/CODE_OF_CONDUCT.md) as well as the [GitHub Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines). Failure to comply may result in exclusion from MDN Web Docs and/or GitHub.
+        - Check for an [existing issue](https://github.com/mdn/browser-compat-data/issues) first. If someone else has opened an issue describing the same problem, please upvote their issue rather than creating another one.
+        - Keep issues relevant to the project. Irrelevant issues will be automatically closed and marked as spam, and repeated offenses may result in exclusion from MDN Web Docs.
+        - Provide as much detail as possible. The more detail you are able to provide, the better!
+        - Write issues primarily in English. While translation tools are available, we will be able to provide better assistance with pre-translated content. You are more than welcome to include a version of the issue body in your preferred language alongside the English version.
+
+        ---
+  - type: checkboxes
+    id: browser
+    attributes:
+      label: Tested on
+      description: Please select the browsers that you have tested the issue on.
+      options:
+        - label: Safari / any iOS browser (Webkit)
+        - label: Firefox/Tor (Gecko+Quantum)
+        - label: Chrome, Brave, Edge, Opera (Chromium)
+  - type: checkboxes
+    id: latest
+    attributes:
+      label: Latest Version
+      description: Please make sure your browser is maintained and up to date before submitting any issue.
+      options:
+        - label: Yes, my browser is maintained and up to date
+          required: true
+  - type: textarea
+    attributes:
+      label: What page(s) does this issue affect?
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: What could be a potential cause of the issue?
+      options:
+        - Unknown
+        - Front end (Browser compatibility)
+        - Back end (React/NextJS)
+        - System error (VPS problem)
+        - Other
+  - type: textarea
+    id: details
+    attributes:
+      label: Explain what went wrong
+  - type: textarea
+    id: tested
+    attributes:
+      label: Did you test this? If so, how?
+  - type: textarea
+    id: references
+    attributes:
+      label: Can you link to any release notes, caniuse, bugs, pull requests, or MDN pages related to this?
+      description: Link to information that helps us fix this issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, screenshots, screen recordings, or sample code
+  - type: checkboxes
+    id: duplicate
+    attributes:
+      label: Not duplicated
+      description: Please make sure this issue is not a duplicate of an existing issue.
+      options:
+        - label: Yes, I have search for this issue on this repository and none were found
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report(beta).yml
+++ b/.github/ISSUE_TEMPLATE/bug_report(beta).yml
@@ -1,6 +1,6 @@
-name: "Website Bug Report"
+name: "Bug Report (Beta)"
 title: "[Bug] - Title"
-description: Report software bugs on the website.
+description: Report bugs on the website (using the new form GitHub feature).
 labels: ["bug"]
 body:
   - type: markdown


### PR DESCRIPTION
There's a new form issue template that allows people to submit bug reports in a much more user friendly way. You can play around with it by clicking [here](https://github.com/Avdang-OS/Website/issues/new/choose) and choosing `Bug Report (Beta)`.

Sorry for the enormous number of commits in this pull request. Preview is only available after I commit changes and view it on GitHub.

![vibe](https://user-images.githubusercontent.com/51555391/176177206-ec3f9dce-8780-4fe8-b6ac-5eeeac2038d4.gif)