### PR TITLE
Fix link

### DIFF
--- a/src/components/discover.tsx
+++ b/src/components/discover.tsx
@@ -52,7 +52,7 @@ export default function Discover() {
                   <DiscoverCard
                     title="AvdanOS"
                     description="Meet AvdanOS, refining the way we think about operating systems."
-                    link="https://github.com/Avdan-OS/AvdanOS"
+                    link="https://github.com/Avdan-OS"
                   />
                   <DiscoverCard
                     title="Official Website"


### PR DESCRIPTION
Currently the website has a link that redirects to Vacaro and it's because of invalid GitHub link. I fixed the link.

![Screenshot 2022-12-16 at 11 03 28 PM](https://user-images.githubusercontent.com/51555391/208127068-3c9a7728-5d1b-44cb-af1b-87a503908f22.png)

![vibe](https://user-images.githubusercontent.com/51555391/176177206-ec3f9dce-8780-4fe8-b6ac-5eeeac2038d4.gif)