### PR TITLE
Replace <a> with next/link

### DIFF
--- a/src/components/BetaPopup.tsx
+++ b/src/components/BetaPopup.tsx
@@ -1,10 +1,10 @@
 import dynamicWidth from '@/lib/dynamic-width';
 import { Text, Button, Card, ButtonGroup, useTheme } from '@geist-ui/core';
-import NextLink from 'next/link';
+import Link from 'next/link';
 import { useRef } from 'react';
 import { TranslatableText } from './translation/TranslatableText';
 
-const BetaCard = ({ Link }: { Link: string }) => {
+const BetaCard = ({ href }: { href: string }) => {
   const betaContainerRef = useRef<HTMLDivElement>(null);
   const Theme = useTheme();
   dynamicWidth((width) => {
@@ -29,11 +29,11 @@ const BetaCard = ({ Link }: { Link: string }) => {
           >
             <TranslatableText>Close</TranslatableText>
           </Button>
-          <NextLink href={Link}>
+          <Link href={href} legacyBehavior>
             <Button shadow>
               <TranslatableText>Check it out</TranslatableText>
             </Button>
-          </NextLink>
+          </Link>
         </ButtonGroup>
       </Card>
       <style jsx>

--- a/src/components/SupportCard.tsx
+++ b/src/components/SupportCard.tsx
@@ -2,6 +2,7 @@ import { Button, Card, Spacer, useTheme, Tag, Grid } from '@geist-ui/core';
 import { TranslatableText } from './translation/TranslatableText';
 import { FaDiscord, FaInstagram, FaTwitter, FaReddit } from 'react-icons/fa';
 import { AiFillYoutube, AiFillGithub } from 'react-icons/ai';
+import Link from 'next/link';
 
 interface SupportCardProps {
   icon: string;
@@ -43,12 +44,12 @@ const SupportCard = ({ icon, title, link, mobileLayout }: SupportCardProps) => {
           <TranslatableText>{title}</TranslatableText>
         </Tag>
         <Spacer />
-        <a href={link} target="_blank" rel="noreferrer">
+        <Link href={link} target="_blank" rel="noreferrer">
           <Button type="success" width={0.7} shadow margin="9px">
             <TranslatableText>Visit</TranslatableText>
             {mobileLayout}
           </Button>
-        </a>
+        </Link>
         <Spacer h={3} />
       </Card>
     </Grid>

--- a/src/components/SupportCardBeta.tsx
+++ b/src/components/SupportCardBeta.tsx
@@ -1,5 +1,5 @@
 import { Text, Card, Divider } from '@geist-ui/core';
-import NextLink from 'next/link';
+import Link from 'next/link';
 interface SupportCardProps {
   title: string;
   description: string;
@@ -18,7 +18,7 @@ const SupportCard = ({ title, description, urlToPost }: SupportCardProps) => {
       <Card.Content>
         <Text>
           {description.substring(0, 150)} {''}
-          {<NextLink href={urlToPost}>read more</NextLink>}
+          {<Link href={urlToPost}>read more</Link>}
         </Text>
       </Card.Content>
     </Card>

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,13 +1,11 @@
 import { Image } from '@geist-ui/core';
 import { useTheme } from '@geist-ui/core';
-import NextLink from 'next/link';
+import Link from 'next/link';
 const Logo = () => {
   return (
-    <NextLink href="/">
-      <a>
-        <Image src={renderElement()} style={{ width: 50, height: 50, pointerEvents: 'none' }} alt="AvdanOS Logo" />
-      </a>
-    </NextLink>
+    <Link href="/" legacyBehavior>
+      <Image src={renderElement()} style={{ width: 50, height: 50, pointerEvents: 'none' }} alt="AvdanOS Logo" />
+    </Link>
   );
 };
 

--- a/src/components/media.tsx
+++ b/src/components/media.tsx
@@ -2,51 +2,52 @@ import { Grid, Card } from '@geist-ui/core';
 import { RiTwitterFill } from 'react-icons/ri';
 import { AiFillYoutube, AiFillGithub } from 'react-icons/ai';
 import { FaRedditAlien, FaDiscord, FaInstagram } from 'react-icons/fa';
+import Link from 'next/link';
 
 const Media = () => {
   return (
     <Grid.Container gap={1} justify="center">
       <Grid>
-        <a href="https://twitter.com/avdan_os" target="_blank" rel="noreferrer">
+        <Link href="https://twitter.com/avdan_os" target="_blank" rel="noreferrer">
           <Card shadow>
             <RiTwitterFill size={26} />
           </Card>
-        </a>
+        </Link>
       </Grid>
       <Grid>
-        <a href="https://github.com/Avdan-OS/" target="_blank" rel="noreferrer">
+        <Link href="https://github.com/Avdan-OS/" target="_blank" rel="noreferrer">
           <Card shadow>
             <AiFillGithub size={26} />
           </Card>
-        </a>
+        </Link>
       </Grid>
       <Grid>
-        <a href="https://www.youtube.com/channel/UCHLCBj83J7bR82HwjhCJusA" target="_blank" rel="noreferrer">
+        <Link href="https://www.youtube.com/channel/UCHLCBj83J7bR82HwjhCJusA" target="_blank" rel="noreferrer">
           <Card shadow>
             <AiFillYoutube size={26} />
           </Card>
-        </a>
+        </Link>
       </Grid>
       <Grid>
-        <a href="https://avdanos.org/discord" target="_blank" rel="noreferrer">
+        <Link href="https://avdanos.org/discord" target="_blank" rel="noreferrer">
           <Card shadow>
             <FaDiscord size={26} />
           </Card>
-        </a>
+        </Link>
       </Grid>
       <Grid>
-        <a href="https://www.reddit.com/r/AvdanOS/" target="_blank" rel="noreferrer">
+        <Link href="https://www.reddit.com/r/AvdanOS/" target="_blank" rel="noreferrer">
           <Card shadow>
             <FaRedditAlien size={26} />
           </Card>
-        </a>
+        </Link>
       </Grid>
       <Grid>
-        <a href="https://www.instagram.com/avdanos_" target="_blank" rel="noreferrer">
+        <Link href="https://www.instagram.com/avdanos_" target="_blank" rel="noreferrer">
           <Card shadow>
             <FaInstagram size={26} />
           </Card>
-        </a>
+        </Link>
       </Grid>
     </Grid.Container>
   );

--- a/src/components/miniFeatures.tsx
+++ b/src/components/miniFeatures.tsx
@@ -1,5 +1,5 @@
 import { Button, Text, Spacer } from '@geist-ui/core';
-import NextLink from 'next/link';
+import Link from 'next/link';
 import { TranslatableText } from '@/components/translation/TranslatableText';
 import SlideshowExplainer from '@/components/slideshowExplainer';
 
@@ -28,11 +28,11 @@ const MiniFeatures = () => {
             <TranslatableText>Check what AvdanOS offers to you.</TranslatableText>
           </Text>
 
-          <NextLink href="/features-beta">
+          <Link href="/features-beta">
             <Button shadow type="success" color="primary">
               <TranslatableText>See here</TranslatableText>
             </Button>
-          </NextLink>
+          </Link>
         </div>
       </div>
     </>

--- a/src/components/navigation/footer.tsx
+++ b/src/components/navigation/footer.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import NextLink from 'next/link';
+import Link from 'next/link';
 import { useTheme, Tag, Spacer } from '@geist-ui/core';
 import Logo from '../logo';
 import dynamicWidth from '@/lib/dynamic-width';
@@ -29,39 +29,29 @@ const Footer: React.FC = () => {
               </h3>
               <ul>
                 <li>
-                  <NextLink href="/">
-                    <a>
-                      <TranslatableText>Home</TranslatableText>
-                    </a>
-                  </NextLink>
+                  <Link href="/">
+                    <TranslatableText>Home</TranslatableText>
+                  </Link>
                 </li>
                 <li>
-                  <NextLink href={`/features${useFeaturesBeta ? '-beta' : ''}`}>
-                    <a>
-                      <TranslatableText>Features</TranslatableText>
-                    </a>
-                  </NextLink>
+                  <Link href={`/features${useFeaturesBeta ? '-beta' : ''}`}>
+                    <TranslatableText>Features</TranslatableText>
+                  </Link>
                 </li>
                 <li>
-                  <NextLink href="/downloads">
-                    <a>
-                      <TranslatableText>Downloads</TranslatableText>
-                    </a>
-                  </NextLink>
+                  <Link href="/downloads">
+                    <TranslatableText>Downloads</TranslatableText>
+                  </Link>
                 </li>
                 <li>
-                  <NextLink href="/support">
-                    <a>
-                      <TranslatableText>Support</TranslatableText>
-                    </a>
-                  </NextLink>
+                  <Link href="/support">
+                    <TranslatableText>Support</TranslatableText>
+                  </Link>
                 </li>
                 <li>
-                  <NextLink href="/docs">
-                    <a>
-                      <TranslatableText>Documentation</TranslatableText>
-                    </a>
-                  </NextLink>
+                  <Link href="/docs">
+                    <TranslatableText>Documentation</TranslatableText>
+                  </Link>
                 </li>
               </ul>
             </div>
@@ -73,34 +63,38 @@ const Footer: React.FC = () => {
               </h3>
               <ul>
                 <li>
-                  <a href="https://twitter.com/avdan_os" target="_blank" rel="noreferrer">
+                  <Link href="https://twitter.com/avdan_os" target="_blank" rel="noreferrer">
                     <TranslatableText>Twitter</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
                 <li>
-                  <a href="https://github.com/Avdan-OS/" target="_blank" rel="noreferrer">
+                  <Link href="https://github.com/Avdan-OS/" target="_blank" rel="noreferrer">
                     <TranslatableText>GitHub</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
                 <li>
-                  <a href="https://www.youtube.com/channel/UCHLCBj83J7bR82HwjhCJusA" target="_blank" rel="noreferrer">
+                  <Link
+                    href="https://www.youtube.com/channel/UCHLCBj83J7bR82HwjhCJusA"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     <TranslatableText>YouTube</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
                 <li>
-                  <a href="https://avdanos.org/discord" target="_blank" rel="noreferrer">
+                  <Link href="https://avdanos.org/discord" target="_blank" rel="noreferrer">
                     <TranslatableText>Discord</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
                 <li>
-                  <a href="https://www.reddit.com/r/AvdanOS/" target="_blank" rel="noreferrer">
+                  <Link href="https://www.reddit.com/r/AvdanOS/" target="_blank" rel="noreferrer">
                     <TranslatableText>Reddit</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
                 <li>
-                  <a href="https://instagram.com/avdanos_" target="_blank" rel="noreferrer">
+                  <Link href="https://instagram.com/avdanos_" target="_blank" rel="noreferrer">
                     <TranslatableText>Instagram</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
               </ul>
             </div>
@@ -130,14 +124,14 @@ const Footer: React.FC = () => {
               </h3>
               <ul>
                 <li>
-                  <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">
+                  <Link href="https://www.gnu.org/licenses/gpl-3.0.en.html">
                     <TranslatableText>License</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
                 <li>
-                  <a href="/eula">
+                  <Link href="/eula">
                     <TranslatableText>EULA</TranslatableText>
-                  </a>
+                  </Link>
                 </li>
               </ul>
             </div>
@@ -152,17 +146,17 @@ const Footer: React.FC = () => {
           >
             <Tag type="secondary" style={{ color: colorSwitch() }}>
               <strong>
-                <a style={{ color: colorSwitch() }} href="https://dns.avdanos.com">
+                <Link style={{ color: colorSwitch() }} href="https://dns.avdanos.com">
                   <TranslatableText>History of Incidents</TranslatableText>
-                </a>
+                </Link>
               </strong>
             </Tag>
             <Spacer h={0.5} />
             <Tag type="secondary" style={{ color: colorSwitch() }}>
               <strong>
-                <a href="/privacy-security" style={{ color: colorSwitch() }}>
+                <Link href="/privacy-security" style={{ color: colorSwitch() }}>
                   <TranslatableText>Privacy and Security</TranslatableText>
-                </a>
+                </Link>
               </strong>
             </Tag>
             <Spacer h={0.5} />
@@ -176,15 +170,15 @@ const Footer: React.FC = () => {
         <p className="copyright" style={{ marginTop: '-10px', marginBottom: '0', fontSize: '13px', opacity: '0.7' }}>
           ©{' '}
           <strong>
-            <a style={{ color: colorSwitch() }} href="https://github.com/Avdan-OS">
+            <Link style={{ color: colorSwitch() }} href="https://github.com/Avdan-OS">
               <TranslatableText>AvdanOS Contributors</TranslatableText>
-            </a>
+            </Link>
           </strong>{' '}
           under{' '}
           <strong>
-            <a style={{ color: colorSwitch() }} href="https://www.gnu.org/licenses/gpl-3.0.en.html">
+            <Link style={{ color: colorSwitch() }} href="https://www.gnu.org/licenses/gpl-3.0.en.html">
               GPL-3.0
-            </a>
+            </Link>
           </strong>
           , {new Date().getFullYear()}
         </p>

--- a/src/components/navigation/menu.tsx
+++ b/src/components/navigation/menu.tsx
@@ -3,7 +3,7 @@ import { Sun, Moon, Download } from 'react-feather';
 import { usePrefers } from '@/lib/use-prefers';
 import { useRouter } from 'next/router';
 import Logo from '../logo';
-import NextLink from 'next/link';
+import Link from 'next/link';
 import Submenu from '@/components/navigation/submenu';
 import TranslationList from '../translation/TranslationList';
 import dynamicWidth from '@/lib/dynamic-width';
@@ -103,40 +103,38 @@ const Menu = () => {
             onClick={() => changeTheme()}
           ></Button>
           <TranslationList />
-          <NextLink href="/downloads" passHref>
-            <a>
-              <Button
-                aria-label="Open Download page"
-                className="theme-button theme-button-cyan"
-                auto
-                shadow
-                type="success"
-                iconRight={<Download className="theme-buttonicon" size={16} />}
-              ></Button>
-            </a>
-          </NextLink>
+          <Link href="/downloads" passHref>
+            <Button
+              aria-label="Open Download page"
+              className="theme-button theme-button-cyan"
+              auto
+              shadow
+              type="success"
+              iconRight={<Download className="theme-buttonicon" size={16} />}
+            ></Button>
+          </Link>
           {!useAltMenuPosition ? null : <MenuBar />}
         </div>
       </nav>
       <Submenu />
       <style>{`
-        .theme-button {
-          margin: 0 ${theme.layout.gapHalf};
-          
-        }
-        .theme-button-cyan {
-          background-color: ${theme.palette.cyan} !important;
-        }
-    
-        .header-dark-tabs {
-          border-radius: 6px;
-          color: #fff;
-          border: 1px solid #333;
-          backdrop-filter: blur(2rem);
-          background: rgba(0, 0, 0, 0.2) !important;
-          -webkit-backdrop-filter: blur(2rem);
-          padding-right: 6px !important;
-      `}</style>
+      .theme-button {
+        margin: 0 ${theme.layout.gapHalf};
+        
+      }
+      .theme-button-cyan {
+        background-color: ${theme.palette.cyan} !important;
+      }
+  
+      .header-dark-tabs {
+        border-radius: 6px;
+        color: #fff;
+        border: 1px solid #333;
+        backdrop-filter: blur(2rem);
+        background: rgba(0, 0, 0, 0.2) !important;
+        -webkit-backdrop-filter: blur(2rem);
+        padding-right: 6px !important;
+    `}</style>
     </>
   );
 };

--- a/src/components/translation/StyleInjector.tsx
+++ b/src/components/translation/StyleInjector.tsx
@@ -19,9 +19,9 @@ const injectStyle = (text: string, link?: string, linkStyle?: CSSProperties) => 
     return (
       <>
         {injectBold(splittedText[0])}
-        <a href={link} style={linkStyle}>
+        <Link href={link} style={linkStyle}>
           {injectBold(splittedText[1])}
-        </a>
+        </Link>
         {injectBold(splittedText[2])}
       </>
     );

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -863,9 +863,9 @@
       "peer": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001407",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz",
-      "integrity": "sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -874,6 +874,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -3708,9 +3712,9 @@
       "peer": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001407",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz",
-      "integrity": "sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w=="
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg=="
     },
     "ccount": {
       "version": "2.0.1",

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,6 +1,7 @@
 import { TranslatableText } from '@/components/translation/TranslatableText';
 import { Note } from '@geist-ui/core';
 import Head from 'next/head';
+import Link from 'next/link';
 
 const Page404 = () => {
   return (
@@ -17,7 +18,7 @@ const Page404 = () => {
           <TranslatableText>This page does not exist.</TranslatableText>
         </h4>
         <Note style={{ display: 'inline-block' }} type="warning" label="Tip">
-          Join in and <a href="https://github.com/avdan-os">help us</a> out developing an{' '}
+          Join in and <Link href="https://github.com/avdan-os">help us</Link> out developing an{' '}
           <strong>open-source operating system</strong>.
         </Note>
       </div>

--- a/src/pages/features-beta.tsx
+++ b/src/pages/features-beta.tsx
@@ -1,6 +1,6 @@
 import { Spacer, Card, Button, Text, useTheme } from '@geist-ui/core';
 import { useEffect, useState, useRef } from 'react';
-import NextLink from 'next/link';
+import Link from 'next/link';
 import Media from '@/components/media';
 import FeaturesBetaCard from '@/components/FeaturesBetaCard';
 import WidthRequirement from '@/components/WidthRequirement';
@@ -83,9 +83,9 @@ const Features = () => {
             style={{ width: '100%', height: '100%' }}
           >
             {/* 
-              The video source should have 100% i-frame and no p/b-frame and consistent frame rate, or the video will lag.
-              20fps 720p vp9 webm g=1 is recommended when serving the video over cdn.
-            */}
+            The video source should have 100% i-frame and no p/b-frame and consistent frame rate, or the video will lag.
+            20fps 720p vp9 webm g=1 is recommended when serving the video over cdn.
+          */}
             <source
               type="video/webm"
               src={`assets/clips/features${theme.type === 'light' ? '_light' : ''}.webm`}
@@ -97,11 +97,11 @@ const Features = () => {
         <div className="slide">
           <Card className="slide__card slide__card-left" color={theme.type === 'light' ? 'black' : 'white'}>
             <TranslatableText>This concept video is made by Avdan</TranslatableText> <Spacer />
-            <NextLink href="https://youtu.be/tXFEiw1aJTw">
+            <Link href="https://youtu.be/tXFEiw1aJTw">
               <Button type="error">
                 <TranslatableText>Watch on YouTube</TranslatableText>
               </Button>
-            </NextLink>
+            </Link>
           </Card>
 
           <Spacer h="700px" />
@@ -187,11 +187,11 @@ const Features = () => {
         <Spacer h="50px" />
         <Media />
         <Spacer h="50px" />
-        <NextLink href="/demo">
+        <Link href="/demo">
           <Button shadow type="success" margin="10px">
             <TranslatableText>Open demo</TranslatableText>
           </Button>
-        </NextLink>
+        </Link>
         <style jsx global>
           {`
             #__next {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Text, Spacer, useTheme } from '@geist-ui/core';
-import NextLink from 'next/link';
+import Link from 'next/link';
 import dynamicWidth from '@/lib/dynamic-width';
 import { useState } from 'react';
 import Discover from '@/components/discover';
@@ -29,17 +29,17 @@ const index = () => {
         <div className="center card-container">
           <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
             {useMobileBar ? null : (
-              <NextLink href="/demo">
+              <Link href="/demo">
                 <Button shadow type="secondary" margin="10px">
                   <TranslatableText>Try in your browser</TranslatableText>
                 </Button>
-              </NextLink>
+              </Link>
             )}
-            <NextLink href="/downloads">
+            <Link href="/downloads">
               <Button shadow type="success" margin="10px">
                 <TranslatableText>Download Now!</TranslatableText>
               </Button>
-            </NextLink>
+            </Link>
           </div>
         </div>
         <Spacer h="35vh" />
@@ -56,17 +56,17 @@ const index = () => {
           </Text>
           <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
             {useMobileBar ? null : (
-              <NextLink href="/demo">
+              <Link href="/demo">
                 <Button shadow type="secondary" margin="10px">
                   <TranslatableText>Try in your browser</TranslatableText>
                 </Button>
-              </NextLink>
+              </Link>
             )}
-            <NextLink href="/downloads">
+            <Link href="/downloads">
               <Button shadow type="success" margin="10px">
                 <TranslatableText>Download Now!</TranslatableText>
               </Button>
-            </NextLink>
+            </Link>
           </div>
         </div>
         <Spacer h={2} />

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -59,7 +59,7 @@ const Support = () => {
           </TranslatableText>
         </Text>
         <Spacer h={5} />
-        <BetaPopup Link="/support-beta" />
+        <BetaPopup href="/support-beta" />
       </div>
     </>
   );


### PR DESCRIPTION
With NextJS 13, `<a>` is basically obsolete and sometimes causes errors. This PR fixes everything by replacing every link with next/link.
[More details](https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor)

![vibe](https://user-images.githubusercontent.com/51555391/176177206-ec3f9dce-8780-4fe8-b6ac-5eeeac2038d4.gif)