### PR TITLE
Add mastodon.social links to footer

### DIFF
--- a/src/components/navigation/footer.tsx
+++ b/src/components/navigation/footer.tsx
@@ -96,6 +96,11 @@ const Footer: React.FC = () => {
                     <Chiislate>Instagram</Chiislate>
                   </Link>
                 </li>
+                <li>
+                  <Link href="https://mastodon.social/@avdan_os" target="_blank" rel="me">
+                    <Chiislate>Mastodon</Chiislate>
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>

--- a/src/public/assets/lang/ar-SA.yaml
+++ b/src/public/assets/lang/ar-SA.yaml
@@ -9,6 +9,7 @@ External Links: روابط خارجية
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: قانوني

--- a/src/public/assets/lang/da-DK.yaml
+++ b/src/public/assets/lang/da-DK.yaml
@@ -9,6 +9,7 @@ External links: Eksterne links
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Juridisk

--- a/src/public/assets/lang/de-DE.yaml
+++ b/src/public/assets/lang/de-DE.yaml
@@ -9,6 +9,7 @@ External links: Externe Links
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Rechtliches

--- a/src/public/assets/lang/el-GR.yaml
+++ b/src/public/assets/lang/el-GR.yaml
@@ -9,6 +9,7 @@ External links: links τρίτων
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: νόμιμη

--- a/src/public/assets/lang/en-GB.yaml
+++ b/src/public/assets/lang/en-GB.yaml
@@ -9,6 +9,7 @@ External links:
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal:

--- a/src/public/assets/lang/en-US.yaml
+++ b/src/public/assets/lang/en-US.yaml
@@ -9,6 +9,7 @@ External links:
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal:

--- a/src/public/assets/lang/es-ES.yaml
+++ b/src/public/assets/lang/es-ES.yaml
@@ -9,6 +9,7 @@ External links: Enlaces externos
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal:

--- a/src/public/assets/lang/fr-FR.yaml
+++ b/src/public/assets/lang/fr-FR.yaml
@@ -9,6 +9,7 @@ External links: Liens externes
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Légal

--- a/src/public/assets/lang/ga-IE.yaml
+++ b/src/public/assets/lang/ga-IE.yaml
@@ -9,6 +9,7 @@ External links: Naisc Sheachtracha
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Dlíthiúil

--- a/src/public/assets/lang/hi-IN.yaml
+++ b/src/public/assets/lang/hi-IN.yaml
@@ -9,6 +9,7 @@ External links: बाहरी संबंध
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: कानूनी

--- a/src/public/assets/lang/id-ID.yaml
+++ b/src/public/assets/lang/id-ID.yaml
@@ -9,6 +9,7 @@ External links: Tautan Eksternal
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Hukum

--- a/src/public/assets/lang/it-IT.yaml
+++ b/src/public/assets/lang/it-IT.yaml
@@ -9,6 +9,7 @@ External links: Link esterni
 Twitter: Twitter
 GitHub: GitHub
 YouTube: YouTube
+Mastodon:
 Discord: Discord
 Reddit: Reddit
 Legal: Legale

--- a/src/public/assets/lang/ja-JP.yaml
+++ b/src/public/assets/lang/ja-JP.yaml
@@ -9,6 +9,7 @@ External links:
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: 法定

--- a/src/public/assets/lang/nl-NL.yaml
+++ b/src/public/assets/lang/nl-NL.yaml
@@ -9,6 +9,7 @@ External links: Externe links
 Twitter: Twitter
 GitHub: GitHub
 YouTube: YouTube
+Mastodon:
 Discord: Discord
 Reddit: Reddit
 Legal: Legaal

--- a/src/public/assets/lang/pl.yaml
+++ b/src/public/assets/lang/pl.yaml
@@ -9,6 +9,7 @@ External links: Linki zewnętrzne
 Twitter: Twitter
 GitHub: GitHub
 YouTube: YouTube
+Mastodon:
 Discord: Discord
 Reddit: Reddit
 Legal: Leaglność

--- a/src/public/assets/lang/pt-BR.yaml
+++ b/src/public/assets/lang/pt-BR.yaml
@@ -9,6 +9,7 @@ External links: Links Externos
 Twitter: Twitter
 GitHub: GitHub
 YouTube: YouTube
+Mastodon:
 Discord: Discord
 Reddit: Reddit
 Legal: Termos legais

--- a/src/public/assets/lang/ru.yaml
+++ b/src/public/assets/lang/ru.yaml
@@ -9,6 +9,7 @@ External links: Внешние ссылки
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Прочее

--- a/src/public/assets/lang/sr-SP.yaml
+++ b/src/public/assets/lang/sr-SP.yaml
@@ -9,6 +9,7 @@ External links: Спољни линкови
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Правно

--- a/src/public/assets/lang/sv-SE.yaml
+++ b/src/public/assets/lang/sv-SE.yaml
@@ -9,6 +9,7 @@ External links: Externa länkar
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Juridiskt

--- a/src/public/assets/lang/tr-TR.yaml
+++ b/src/public/assets/lang/tr-TR.yaml
@@ -9,6 +9,7 @@ External links: Harici Bağlantılar
 Twitter:
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: Yasal

--- a/src/public/assets/lang/zh-CN.yaml
+++ b/src/public/assets/lang/zh-CN.yaml
@@ -9,6 +9,7 @@ External links: 外部连结
 Twitter: 推特
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: 法定

--- a/src/public/assets/lang/zh-TW.yaml
+++ b/src/public/assets/lang/zh-TW.yaml
@@ -9,6 +9,7 @@ External links: 外部連結
 Twitter: 推特
 GitHub:
 YouTube:
+Mastodon:
 Discord:
 Reddit:
 Legal: 法定


### PR DESCRIPTION
(See individual commit messages for more info.)

Yes, I know there is a missing bit in the "Support" page.
Idk if I should add that too.