### PR TITLE
Fix language picker sync & optimize features.webm

### DIFF
--- a/src/components/translation/TranslationList.tsx
+++ b/src/components/translation/TranslationList.tsx
@@ -164,10 +164,19 @@ const TranslationList = () => {
   const [defaultLang, setDfltLang] = useState('en-GB');
   useEffect(() => {
     let locale = window.localStorage.getItem('locale');
+    if (!locale) locale = Intl.NumberFormat().resolvedOptions().locale;
+
     if (locale) {
-      setDfltLang(locale);
+      const isExactMatch = data.some((e) => e.lang === locale);
+      if (isExactMatch) {
+        setDfltLang(locale);
+      } else {
+        const languageOnly = locale.split('-')[0];
+        const partialMatch = data.find((e) => e.lang.startsWith(languageOnly));
+        if (partialMatch) setDfltLang(partialMatch.lang);
+      }
     }
-  });
+  }, []);
   return (
     <Select
       type="default"


### PR DESCRIPTION
This PR resolves two long-standing issues affecting website localization and load performance

---

### 1. Translation Picker Sync Fix
**Issue:** The site correctly displayed the user's localized language, but the top-nav language picker component incorrectly defaulted to GB on initial load if `localStorage` was empty.

**Fix:** Updated the `useEffect` initialization in the [TranslationList.tsx](src/components/translation/TranslationList.tsx) component to fallback to the browser's native locale.

**Logic Explanation:** It first pulls from `localStorage`. If that's empty, it uses `Intl.NumberFormat().resolvedOptions().locale`. It then performs an exact match against our language data; if an exact match isn't found (e.g., `en-AU`), it performs a fallback "language-only" match (checking for just `en`) to ensure the picker stays in sync.

**Resolves:** Avdan-OS/Website#574

---

### 2. Media Optimisation
**Issue:** The [features.webm](cdn/features.webm) file was over 90MB. Way too big for a web asset.

**Fix:** Transcoded the raw WebM file using Handbrake (VP9 codec, constant quality, slower compression preset).

**Resolves:** Avdan-OS/Website#455

---
### Files Changed
- [src/components/translation/TranslationList.tsx](src/components/translation/TranslationList.tsx)
- [cdn/features.webm](cdn/features.webm)

---
**Note:** Go easy on me, this is my first PR for this repo and I haven't touched anything in the org for months. Just crawled out of my cave to ship these fixes. Hope it looks good!